### PR TITLE
modules/download-manager.js: Fix bug preventing completion of downloads.

### DIFF
--- a/modules/download-manager.js
+++ b/modules/download-manager.js
@@ -1053,24 +1053,24 @@ function download_completer (completions) {
         };
     }
     all_word_completer.call(this, forward_keywords(arguments),
-                            $completions = completions);
+                            $completions = completions,
+                            $get_string = function (x) {
+                                if (use_downloads_jsm)
+                                    return x.target.path;
+                                else
+                                    return x.displayName;
+                            },
+                            $get_description = function (x) {
+                                if (use_downloads_jsm)
+                                    return x.source.url;
+                                else
+                                    return x.source.spec
+                            });
 }
 download_completer.prototype = {
     constructor: download_completer,
     __proto__: all_word_completer.prototype,
-    toString: function () "#<download_completer>",
-    get_string: function (x) {
-        if (use_downloads_jsm)
-            return x.target.path;
-        else
-            return x.displayName;
-    },
-    get_description: function (x) {
-        if (use_downloads_jsm)
-            return x.source.url;
-        else
-            return x.source.spec
-    }
+    toString: function () "#<download_completer>"
 };
 
 minibuffer.prototype.read_download = function () {


### PR DESCRIPTION
This pull request addresses issue 484 (http://bugs.conkeror.org/issue484).  Be advised that I'm not terribly familiar with how this prototype-based class system stuff is supposed to work, but the changes agree with how other completers are implemented throughout the code and, more importantly, fix the problem.