### PR TITLE
Remove array comprehensions as they are unsupported in Firefox 47.

### DIFF
--- a/modules/utils.js
+++ b/modules/utils.js
@@ -405,10 +405,9 @@ var xml_http_request_load_listener = {
   // Ci.nsISSLErrorListener in 2007 versions of xulrunner 1.9pre.
   // make it a simple generateQI when xulrunner is more stable.
   QueryInterface: XPCOMUtils.generateQI(
-      [i for each (i in [Ci.nsIBadCertListener2,
-                         Ci.nsISSLErrorListener,
-                         Ci.nsIInterfaceRequestor])
-       if (i)])
+      [Ci.nsIBadCertListener2,
+       Ci.nsISSLErrorListener,
+       Ci.nsIInterfaceRequestor])
 };
 
 
@@ -576,8 +575,11 @@ function get_contents_synchronously (url) {
  * load_spec.
  */
 function make_post_data (data) {
-    data = [(encodeURIComponent(pair[0])+'='+encodeURIComponent(pair[1]))
-            for each (pair in data)].join('&');
+    var temp = [];
+    for (let pair of data) {
+        temp.push(encodeURIComponent(pair[0])+'='+encodeURIComponent(pair[1]));
+    }
+    data = temp.join('&');
     data = string_input_stream(data);
     return mime_input_stream(
         data, [["Content-Type", "application/x-www-form-urlencoded"]]);

--- a/modules/webjump.js
+++ b/modules/webjump.js
@@ -146,8 +146,12 @@ function get_url_or_webjump (input) {
 // a webjump completer is a nesting of two completers: one that completes
 // on webjump names, and one specific to the individual webjump.
 function webjump_name_completer () {
+    var completions = [];
+    for (let [k,v] of Iterator(webjumps)) {
+        completions.push(v);
+    }
     prefix_completer.call(this,
-        $completions = [v for ([k, v] in Iterator(webjumps))],
+        $completions = completions,
         $get_string = function (x) x.name + (x.argument == false ? "" : " "),
         $get_description = function (x) x.doc || "");
 }


### PR DESCRIPTION
This removes the use of array comprehensions, as they are not supported in Firefox 47 nightlies.  This obviously will have to happen at some point anyway, and this is also very useful at the moment because the current stable (44) breaks the addon manager, and a fix is only available in recent Firefox 47 nightly builds.
