### PR TITLE
Added text editing ability to isearch-keymap

### DIFF
--- a/modules/bindings/default/bindings.js
+++ b/modules/bindings/default/bindings.js
@@ -45,7 +45,7 @@ define_keymap("minibuffer_keymap", $parent = minibuffer_base_keymap);
 define_keymap("minibuffer_space_completion_keymap");
 define_keymap("hint_keymap", $parent = text_keymap);
 define_keymap("hint_quote_next_keymap");
-define_keymap("isearch_keymap");
+define_keymap("isearch_keymap", $parent = text_keymap);
 
 define_keymap("single_character_options_minibuffer_keymap");
 define_keymap("minibuffer_message_keymap");

--- a/modules/bindings/default/isearch.js
+++ b/modules/bindings/default/isearch.js
@@ -9,8 +9,6 @@
 
 define_fallthrough(isearch_keymap, match_any_unmodified_character);
 
-define_key(isearch_keymap, match_any_unmodified_character, null, $fallthrough);
-
 define_key(isearch_keymap, "back_space", "isearch-backspace");
 define_key(isearch_keymap, "C-r", "isearch-continue-backward");
 define_key(isearch_keymap, "C-s", "isearch-continue-forward");
@@ -19,4 +17,4 @@ define_key(isearch_keymap, "escape", "minibuffer-abort");
 define_key(isearch_keymap, "M-escape", "minibuffer-abort");
 define_key(isearch_keymap, "C-y", "yank");
 
-define_key(isearch_keymap, match_any_key, "isearch-done");
+define_key(isearch_keymap, "return", "isearch-done");

--- a/modules/isearch.js
+++ b/modules/isearch.js
@@ -246,9 +246,7 @@ isearch_session.prototype = {
     },
 
     handle_input: function (m) {
-        m._set_selection();
         this.find(m._input_text, this.top.direction, this.top.point);
-        this.restore_state();
     },
 
     done: false,


### PR DESCRIPTION
As isearch-keymap is not derived from text-keymap, it does not respond to basic editing commands (like M-f C-e etc). Opposingly minibuffer works alike Emacs, I tried to match their functionalities.
