### PR TITLE
add network.standard-url.escape-utf8 preference

### DIFF
--- a/modules/content-buffer.js
+++ b/modules/content-buffer.js
@@ -29,6 +29,9 @@ define_current_buffer_hook("current_content_buffer_location_change_hook", "conte
 define_current_buffer_hook("current_content_buffer_status_change_hook", "content_buffer_status_change_hook");
 define_current_buffer_hook("current_content_buffer_focus_change_hook", "content_buffer_focus_change_hook");
 
+function maybe_decode_uri (uri) {
+    return get_pref("network.standard-url.escape-utf8") ? uri : decodeURIComponent(uri);
+}
 
 function content_buffer_modality (buffer) {
     var elem = buffer.focused_element;
@@ -184,7 +187,7 @@ content_buffer.prototype = {
     },
 
     get title () { return this.browser.contentTitle; },
-    get description () { return this.display_uri_string; },
+    get description () { return maybe_decode_uri(this.display_uri_string); },
 
     load: function (load_spec) {
         apply_load_spec(this, load_spec);
@@ -422,7 +425,7 @@ minibuffer.prototype.read_url = function () {
  */
 function overlink_update_status (buffer, node) {
     if (node && node.href.length > 0)
-        buffer.window.minibuffer.show("Link: " + node.href);
+        buffer.window.minibuffer.show("Link: " + maybe_decode_uri(node.href));
     else
         buffer.window.minibuffer.clear();
 }

--- a/modules/history.js
+++ b/modules/history.js
@@ -19,7 +19,7 @@ history_completions.prototype = {
     toString: function () "#<history_completions>",
     root: null,
     destroy: function () { this.root.containerOpen = false; },
-    get_string: function (i) this.root.getChild(i).uri,
+    get_string: function (i) maybe_decode_uri(this.root.getChild(i).uri),
     get_description: function (i) this.root.getChild(i).title,
     get_value: function (i) this.root.getChild(i),
 };


### PR DESCRIPTION
This change makes network.standard-url.escape-utf8 work as described in http://kb.mozillazine.org/Network.standard-url.escape-utf8 
![after](https://cloud.githubusercontent.com/assets/251267/23612985/f17c876a-0296-11e7-93a6-df63635a8c9f.png)
